### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Sycorax
 sentence=
 paragraph=
 category=Timing
-url=.
+url=https://github.com/sycorax/RS1302_simple
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.